### PR TITLE
switch to recognized CVE sample IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Fail if any vulnerabilities equal to or over this severity level are detected. V
 
 ### `ignoreList`
 
-List of CVEs that can be safely ignored and should not fail the scan. List should be separated by commas. eg 'CVE-2022-1234,CVE-2022-4321'
+List of CVEs that can be safely ignored and should not fail the scan. List should be separated by commas. eg 'CVE-2014-54321,CVE-2014-456132'
 
 ## Outputs
 


### PR DESCRIPTION
During the syntax change, MITRE made several CVE IDs specifically for referencing in cases like this, rather than IDs that may be legitimate CVEs. They include:
CVE-2014-9999
CVE-2014-99999
CVE-2014-999999
CVE-2014-54321
CVE-2014-456132
CVE-2014-123456
CVE-2014-10000
CVE-2014-100000